### PR TITLE
chore(deps): update requirements.txt to latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,65 +1,65 @@
 # Core Python packages
-setuptools==70.0.0
-pip==25.0
+setuptools==82.0.1
+pip==26.0.1
 
 # Django and REST Framework
-Django==5.1.1
-djangorestframework==3.15.2
-django-filter==24.2
+Django==6.0.4
+djangorestframework==3.17.1
+django-filter==25.2
 django-user-agents==0.4.0
-django-model-utils==4.5.1
+django-model-utils==5.0.0
 
 # Database and Data Processing
-psycopg2-binary==2.9.10
-mysql-connector-python==9.1.0
-sqlparse==0.5.0
-tzdata==2024.1
+psycopg2-binary==2.9.11
+mysql-connector-python==9.6.0
+sqlparse==0.5.5
+tzdata==2026.1
 
 # Task Queue & Celery
-celery==5.4.0
-django-celery-beat==2.7.0
-django-celery-results==2.5.1
+celery==5.6.3
+django-celery-beat==2.9.0
+django-celery-results==2.6.0
 
 # Cloud Storage & Services
 ## AWS
-boto3==1.35.22
+boto3==1.42.90
 
 ## Google Cloud
-google-cloud-storage==2.17.0
-google-auth-oauthlib==1.2.0
+google-cloud-storage==3.10.1
+google-auth-oauthlib==1.3.1
 gcloud==0.18.3
 
 ## Azure
-azure-storage-blob==12.16.0
-azure-identity==1.16.1
+azure-storage-blob==12.28.0
+azure-identity==1.25.3
 
 ## Other Cloud Services
-dropbox==11.36.2
-pcloud==1.3
-ibm-cos-sdk==2.13.4
-oss2==2.17.0
-cos-python-sdk-v5==1.9.23
-oci==2.129.0
+dropbox==12.0.2
+pcloud==2.0.1
+ibm-cos-sdk==2.16.2
+oss2==2.19.1
+cos-python-sdk-v5==1.9.41
+oci==2.171.0
 ovh==1.2.0
 
 # File Transfer & Network
-paramiko==3.3.2
-ftputil==5.0.4
-requests==2.32.0
-gunicorn==22.0.0
+paramiko==4.0.0
+ftputil==5.1.0
+requests==2.33.1
+gunicorn==25.3.0
 ipaddress==1.0.23
 
 # Security & Authentication
-python-dotenv==1.0.1
-cryptography==42.0.5
-sentry-sdk==2.8.0
+python-dotenv==1.2.2
+cryptography==46.0.7
+sentry-sdk==2.58.0
 
 # Utilities & Helpers
 humanfriendly==10.0
-humanize==4.3.0
-shortuuid==1.0.11
-phonenumbers==8.13.31
-Pillow==11.1.0
-beautifulsoup4==4.12.3
-slack-sdk==3.18.3
-fake-useragent==2.0.3
+humanize==4.15.0
+shortuuid==1.0.13
+phonenumbers==9.0.28
+Pillow==12.2.0
+beautifulsoup4==4.14.3
+slack-sdk==3.41.0
+fake-useragent==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core Python packages
-setuptools==82.0.1
+# Pinned <81: setuptools 81 removed pkg_resources, which the legacy gcloud==0.18.3 still imports.
+setuptools==80.10.2
 pip==26.0.1
 
 # Django and REST Framework


### PR DESCRIPTION
Bumps all outdated packages to current PyPI releases, including major
version upgrades for Django (5→6), paramiko (3→4), Pillow (11→12),
cryptography (42→46), gunicorn (22→25), phonenumbers (8→9),
google-cloud-storage (2→3), dropbox (11→12), pcloud (1→2), and
django-model-utils (4→5).

https://claude.ai/code/session_01Vcw2rVWNMUYMW9C2ikQrLc