### PR TITLE
feat(onboarding): surface DB-backed branding, polish wizard, add tests

### DIFF
--- a/apps/console/_templates/console/_master.html
+++ b/apps/console/_templates/console/_master.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="h-full bg-white">
 <head>
-    <title>{% block title %}Dashboard{% endblock %}</title>
+    <title>{% block title %}Dashboard{% endblock %} · {{ site.app_name }}</title>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="author" content="{% block author %}MonetizeNow{% endblock %}">

--- a/apps/console/_templates/console/auth/_master.html
+++ b/apps/console/_templates/console/auth/_master.html
@@ -13,7 +13,7 @@
 
         gtag('config', 'G-CTFWTRZC93');
     </script>
-    <title>{% block title %}BackupSheep{% endblock %}</title>
+    <title>{% block title %}{{ site.app_name }}{% endblock %}</title>
     {% if server_type == 'dev' %}
         <meta name="robots" content="noindex,nofollow">
     {% endif %}
@@ -22,14 +22,14 @@
     <meta name="description"
           content="{% block description %}{% endblock %}">
     <meta name="author" content="{% block author %}{% endblock %}">
-    <meta name="og:site_name" content="BackupSheep">
+    <meta name="og:site_name" content="{{ site.app_name }}">
     <meta name="og:image" content="{{ STATIC_URL }}images/home.png">
     <meta property="og:image:width" content="4284"/>
     <meta property="og:image:height" content="2874"/>
     <meta name="og:description"
           content="{% block og_description %} {% endblock %}">
     <meta name="og:title"
-          content="{% block og_title %}BackupSheep{% endblock %}">
+          content="{% block og_title %}{{ site.app_name }}{% endblock %}">
     <meta name="keywords"
           content="{% block keywords %}automate cloud backups, cloud backups, website backups, database backups{% endblock %}">
     <link rel="shortcuticon" href="{{ STATIC_URL }}images/favicon.ico" type="image/x-icon">

--- a/apps/console/_templates/console/emails/_master.html
+++ b/apps/console/_templates/console/emails/_master.html
@@ -444,8 +444,8 @@
           <table class="email-content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
             <tr>
               <td class="email-masthead">
-                <a href="https://backupsheep.com" class="f-fallback email-masthead_name">
-                BackupSheep Notifications
+                <a href="{{ site_app_url|default:'#' }}" class="f-fallback email-masthead_name">
+                {{ site_app_name|default:"BackupSheep" }} Notifications
               </a>
               </td>
             </tr>
@@ -469,7 +469,7 @@
                 <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
                   <tr>
                     <td class="content-cell" align="center">
-                      <p class="f-fallback sub align-center">&copy; 2023 BackupSheep Inc. All rights reserved.</p>
+                      <p class="f-fallback sub align-center">&copy; {{ site_app_name|default:"BackupSheep" }}</p>
 
                     </td>
                   </tr>

--- a/apps/console/_templates/console/onboarding/_base.html
+++ b/apps/console/_templates/console/onboarding/_base.html
@@ -11,6 +11,7 @@
 <body class="bg-gray-50 min-h-screen text-gray-900">
 <div class="max-w-2xl mx-auto px-4 py-10">
     <div class="mb-8">
+        <p class="text-xs font-medium uppercase tracking-wide text-indigo-600 mb-1">Step {{ step }} of {{ steps|length }}</p>
         <h1 class="text-2xl font-semibold">Set up {{ app_name|default:"BackupSheep" }}</h1>
         <p class="text-sm text-gray-500 mt-1">A few steps to get your self-hosted install ready.</p>
     </div>

--- a/apps/console/notification/models.py
+++ b/apps/console/notification/models.py
@@ -74,16 +74,20 @@ class CoreNotificationLogEmail(TimeStampedModel):
         from apps.console.setting.models import CoreSiteSettings
         import json
 
-        self.html_body = render_to_string(f"console/emails/{self.template}.html", self.context)
-        self.text_body = render_to_string(f"console/emails/{self.template}.txt.html", self.context)
-        self.subject = render_to_string(f"console/emails/{self.template}.subject.html", self.context)
+        # Provider + credentials and branding come from the DB-backed site settings
+        # (configured in the onboarding wizard), falling back to the matching .env values.
+        site = CoreSiteSettings.load()
+        app_name = site.get_app_name()
+        app_url = f"{site.get_app_protocol()}{site.get_app_domain()}"
+
+        # render_to_string does not run context processors, so inject branding explicitly.
+        email_context = {**(self.context or {}), "site_app_name": app_name, "site_app_url": app_url}
+        self.html_body = render_to_string(f"console/emails/{self.template}.html", email_context)
+        self.text_body = render_to_string(f"console/emails/{self.template}.txt.html", email_context)
+        self.subject = render_to_string(f"console/emails/{self.template}.subject.html", email_context)
         self.save()
 
-        # Provider + credentials come from the DB-backed site settings (configured in the
-        # onboarding wizard), falling back to the matching .env values.
-        site = CoreSiteSettings.load()
         email_provider = site.get_email_provider()
-        app_name = site.get_app_name()
 
         if email_provider == "mailgun":
             api_url = site.email_cred("api_url", "MAILGUN_API_URL")

--- a/apps/console/onboarding/tests.py
+++ b/apps/console/onboarding/tests.py
@@ -1,0 +1,121 @@
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+
+from apps.console.account.models import CoreAccount
+from apps.console.member.models import CoreMember, CoreMemberAccount
+from apps.console.setting.models import CoreSiteSettings
+from utils.middleware import OnboardingMiddleware
+
+User = get_user_model()
+
+PW = "Sup3r-Secret-Pw!"
+
+
+class OnboardingFlowTests(TestCase):
+    def setUp(self):
+        # OnboardingMiddleware caches "setup completed" in a process-global latch; reset it
+        # so each test starts from a clean, not-configured state.
+        OnboardingMiddleware._completed = False
+        self.client = Client()
+
+    def tearDown(self):
+        OnboardingMiddleware._completed = False
+
+    def _create_admin(self, email="ada@example.com"):
+        return self.client.post(
+            "/onboarding/account/",
+            {"full_name": "Ada Admin", "organization": "Acme", "email": email,
+             "password1": PW, "password2": PW},
+        )
+
+    def test_anonymous_is_forced_into_wizard(self):
+        r = self.client.get("/")
+        self.assertEqual(r.status_code, 302)
+        self.assertTrue(r.headers["Location"].startswith("/onboarding"))
+
+    def test_account_creation_builds_chain_and_logs_in(self):
+        r = self._create_admin()
+        self.assertEqual(r.status_code, 302)
+        self.assertTrue(r.headers["Location"].endswith("/onboarding/settings/"))
+
+        self.assertEqual(User.objects.count(), 1)
+        user = User.objects.get()
+        self.assertFalse(user.is_superuser)  # console is reserved for non-superusers
+        self.assertEqual(CoreMember.objects.count(), 1)
+
+        account = CoreAccount.objects.get()
+        self.assertTrue(account.encryption_key)  # Fernet key generated
+
+        membership = CoreMemberAccount.objects.get()
+        self.assertTrue(membership.primary)
+        self.assertTrue(membership.current)
+        self.assertEqual(membership.status, CoreMemberAccount.Status.ACTIVE)
+
+        self.assertIn("_auth_user_id", self.client.session)  # auto-logged-in
+
+    def test_full_flow_completes_and_locks_wizard(self):
+        self._create_admin()
+        self.client.post(
+            "/onboarding/settings/",
+            {"app_name": "My BS", "app_protocol": "https://", "app_domain": "bs.test",
+             "default_timezone": "UTC"},
+        )
+        self.assertEqual(CoreSiteSettings.load().app_name, "My BS")
+
+        self.client.post("/onboarding/email/", {"email_provider": "none", "action": "continue"})
+
+        r = self.client.post("/onboarding/finish/")
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(r.headers["Location"], "/console")
+        self.assertTrue(CoreSiteSettings.load().setup_completed)
+
+        # Wizard is now locked.
+        r = self.client.get("/onboarding/account/")
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(r.headers["Location"], "/console")
+
+    def test_account_step_refuses_a_second_admin(self):
+        self._create_admin()
+        self.client.logout()
+        OnboardingMiddleware._completed = False
+
+        r = self.client.get("/onboarding/account/")
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "already")
+
+        before = User.objects.count()
+        self._create_admin(email="evil@example.com")
+        self.assertEqual(User.objects.count(), before)
+
+    def test_email_test_action_without_provider_warns_not_crashes(self):
+        self._create_admin()
+        r = self.client.post("/onboarding/email/", {"email_provider": "none", "action": "test"})
+        self.assertEqual(r.status_code, 200)  # re-renders with a warning
+
+    def test_storage_step_lists_seeded_providers(self):
+        self._create_admin()
+        r = self.client.get("/onboarding/storage/")
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "Amazon S3")  # from the seeded catalog
+
+
+class SiteSettingsModelTests(TestCase):
+    def test_email_credentials_encrypted_roundtrip(self):
+        s = CoreSiteSettings.load()
+        s.email_provider = "postmark"
+        s.set_email_credentials({"postmark": {"api_key": "secret-xyz"}})
+        s.save()
+
+        again = CoreSiteSettings.load()
+        self.assertTrue(again.email_credentials_encrypted)
+        self.assertNotIn("secret-xyz", again.email_credentials_encrypted)  # not plaintext
+        self.assertEqual(again.email_credentials["postmark"]["api_key"], "secret-xyz")
+        self.assertEqual(again.email_cred("api_key"), "secret-xyz")
+
+    def test_singleton(self):
+        a = CoreSiteSettings.load()
+        a.app_name = "One"
+        a.save()
+        b = CoreSiteSettings.load()
+        self.assertEqual(a.pk, b.pk)
+        self.assertEqual(CoreSiteSettings.objects.count(), 1)

--- a/backupsheep/settings.py
+++ b/backupsheep/settings.py
@@ -104,6 +104,7 @@ TEMPLATES = [
                 "django.template.context_processors.tz",
                 "django.template.context_processors.i18n",
                 "utils.context_processors.timezone",
+                "utils.context_processors.site",
             ],
         },
     },

--- a/utils/context_processors.py
+++ b/utils/context_processors.py
@@ -1,12 +1,37 @@
 from django.conf import settings
 
 
+def _load_site(request):
+    """Load the CoreSiteSettings singleton once per request (cached on the request)."""
+    s = getattr(request, "_site_settings", None)
+    if s is None:
+        from apps.console.setting.models import CoreSiteSettings
+
+        s = CoreSiteSettings.load()
+        request._site_settings = s
+    return s
+
+
+def site(request):
+    """DB-backed branding (app name + public URL) for all templates, with .env fallback."""
+    s = _load_site(request)
+    return {
+        "site": {
+            "app_name": s.get_app_name(),
+            "app_protocol": s.get_app_protocol(),
+            "app_domain": s.get_app_domain(),
+            "app_url": f"{s.get_app_protocol()}{s.get_app_domain()}",
+        }
+    }
+
+
 def server_code(request):
     return {"server_code": settings.SERVER_CODE}
 
 
 def app_domain(request):
-    return {"app_domain": "https://%s" % settings.APP_DOMAIN}
+    s = _load_site(request)
+    return {"app_domain": f"{s.get_app_protocol()}{s.get_app_domain()}"}
 
 
 def timezone(request):


### PR DESCRIPTION
Follow-ups to the onboarding wizard.

Branding: new `site` context processor (utils/context_processors.py, request-cached) exposes CoreSiteSettings app name + public URL to all templates with .env fallback; registered in TEMPLATES. Web titles (console + auth masters) now use {{ site.app_name }}. Emails can't run context processors via render_to_string, so CoreNotificationLogEmail.send() injects site_app_name/site_app_url into the render context; the email master's masthead + footer now use them instead of the hardcoded backupsheep.com / "BackupSheep Inc.".

Polish: onboarding base shows "Step X of N".

Tests: apps/console/onboarding/tests.py (8 tests, all passing on Postgres) cover the gating middleware (anonymous forced to wizard; wizard locked after completion), the account-creation chain (non-superuser owner + member + account w/ Fernet key + primary membership + auto-login), the full step flow + finish, refusal to create a second admin, the email test action, the seeded storage catalog, and CoreSiteSettings encryption + singleton. The middleware's process-global "completed" latch is reset per test.

manage.py check clean.