### PR TITLE
security: fix command injection, CSRF, weak reset tokens, SSRF, and related issues

### DIFF
--- a/apps/_migrations/0012_coremember_password_reset_token_created.py
+++ b/apps/_migrations/0012_coremember_password_reset_token_created.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('apps', '0011_create_cache_table'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='coremember',
+            name='password_reset_token_created',
+            field=models.DateTimeField(blank=True, editable=False, null=True),
+        ),
+    ]

--- a/apps/_tasks/integration/backup/_sanitize.py
+++ b/apps/_tasks/integration/backup/_sanitize.py
@@ -1,0 +1,65 @@
+"""Input guards for the database backup tasks.
+
+The dump commands in mysql.py / mariadb.py / postgresql.py are built by interpolating
+user-controlled connection/node fields (host, username, database/table names, dump
+options, ...) into shell command strings that are executed with ``shell=True`` or sent
+to a remote ``ssh.exec_command``. Those fields originate from authenticated users and
+are otherwise unvalidated, which makes them a command-injection / path-traversal vector.
+
+Rather than restructure every command builder, these helpers reject values that could
+break out of their interpolation context *before* the command is assembled. Legitimate
+hostnames, usernames, database/table names and dump flags pass untouched; anything that
+could inject a second command (or escape the ``_storage`` directory when used as a dump
+filename) raises ``UnsafeBackupInput``, which the task's existing ``except`` turns into a
+normal backup failure.
+"""
+
+import re
+
+# Single-token values that are interpolated *unquoted* into the command and are also used
+# as on-disk dump filenames (host, port, username, database name, table name). Reject
+# shell metacharacters, whitespace (argument splitting) and path separators (traversal).
+_UNQUOTED_TOKEN_BAD = re.compile(r"""[\s;&|`$<>(){}\[\]\\'"!*?~#/]""")
+
+# Free-form dump option strings (e.g. pg_dump "-w --clean") legitimately contain spaces
+# and dashes, so only reject characters that allow chaining a second command.
+_OPTION_BAD = re.compile(r"""[;&|`$<>(){}\[\]\\'"\n\r]""")
+
+
+class UnsafeBackupInput(ValueError):
+    """Raised when a backup input contains characters that are unsafe to shell out with."""
+
+
+def safe_token(value, field):
+    """Validate a value interpolated unquoted into a command / used as a dump filename."""
+    text = "" if value is None else str(value)
+    if _UNQUOTED_TOKEN_BAD.search(text):
+        raise UnsafeBackupInput(
+            f"Rejected unsafe characters in {field!r}. Remove shell metacharacters, "
+            f"spaces and slashes."
+        )
+    return text
+
+
+def safe_password(value, field="password"):
+    """Validate a value interpolated inside a single-quoted shell context (e.g. PGPASSWORD).
+
+    Inside single quotes the shell treats everything literally, so the only character that
+    can break out is the single quote itself; carriage-return / newline are also rejected
+    so a value can never start a new command line.
+    """
+    text = "" if value is None else str(value)
+    if "'" in text or "\n" in text or "\r" in text:
+        raise UnsafeBackupInput(
+            f"Rejected unsafe characters in {field!r}. Single quotes and newlines are not "
+            f"allowed."
+        )
+    return text
+
+
+def safe_options(value, field):
+    """Validate a free-form dump option string that may contain spaces/dashes."""
+    text = "" if value is None else str(value)
+    if _OPTION_BAD.search(text):
+        raise UnsafeBackupInput(f"Rejected unsafe characters in {field!r}.")
+    return text

--- a/apps/_tasks/integration/backup/mariadb.py
+++ b/apps/_tasks/integration/backup/mariadb.py
@@ -6,6 +6,7 @@ from apps._tasks.exceptions import NodeBackupFailedError
 from apps._tasks.helper.tasks import delete_from_disk
 from apps.api.v1.utils.api_helpers import bs_decrypt, aws_s3_upload_log_file
 from apps.api.v1.utils.api_helpers import zipdir, mkdir_p
+from apps._tasks.integration.backup._sanitize import safe_token, safe_password
 
 
 from apps.console.utils.models import UtilBackup
@@ -68,6 +69,18 @@ def snapshot_mariadb(backup):
 
         database_version_path = node.connection.auth_database.bin_path()
 
+        # Reject command-injection / path-traversal payloads in the user-supplied
+        # connection fields before they are interpolated into the dump commands below.
+        safe_token(node.connection.auth_database.host, "host")
+        safe_token(node.connection.auth_database.port, "port")
+        safe_token(node.connection.auth_database.database_name, "database_name")
+        safe_token(bs_decrypt(node.connection.auth_database.username, encryption_key), "username")
+        safe_password(bs_decrypt(node.connection.auth_database.password, encryption_key), "password")
+        for _name in (node.database.databases or []):
+            safe_token(_name, "databases")
+        for _name in (node.database.tables or []):
+            safe_token(_name, "tables")
+
         if (
                 node.connection.auth_database.use_public_key
                 or node.connection.auth_database.use_private_key
@@ -112,6 +125,7 @@ def snapshot_mariadb(backup):
                         databases.append(database_name)
 
                 for database in databases:
+                    safe_token(database, "database")
 
                     db_file = f"{local_dir}{database}.sql"
 

--- a/apps/_tasks/integration/backup/mysql.py
+++ b/apps/_tasks/integration/backup/mysql.py
@@ -6,6 +6,7 @@ from apps._tasks.exceptions import NodeBackupFailedError
 from apps._tasks.helper.tasks import delete_from_disk
 from apps.api.v1.utils.api_helpers import bs_decrypt, aws_s3_upload_log_file
 from apps.api.v1.utils.api_helpers import zipdir, mkdir_p
+from apps._tasks.integration.backup._sanitize import safe_token, safe_password
 
 
 from django.core.cache import cache
@@ -77,6 +78,18 @@ def snapshot_mysql(backup):
 
         database_version_path = node.connection.auth_database.bin_path()
 
+        # Reject command-injection / path-traversal payloads in the user-supplied
+        # connection fields before they are interpolated into the dump commands below.
+        safe_token(node.connection.auth_database.host, "host")
+        safe_token(node.connection.auth_database.port, "port")
+        safe_token(node.connection.auth_database.database_name, "database_name")
+        safe_token(bs_decrypt(node.connection.auth_database.username, encryption_key), "username")
+        safe_password(bs_decrypt(node.connection.auth_database.password, encryption_key), "password")
+        for _name in (node.database.databases or []):
+            safe_token(_name, "databases")
+        for _name in (node.database.tables or []):
+            safe_token(_name, "tables")
+
         if (
             node.connection.auth_database.use_public_key
             or node.connection.auth_database.use_private_key
@@ -121,6 +134,7 @@ def snapshot_mysql(backup):
                         databases.append(database_name)
 
                 for database in databases:
+                    safe_token(database, "database")
                     db_file = f"{local_dir}{database}.sql"
 
                     username = bs_decrypt(node.connection.auth_database.username, encryption_key)

--- a/apps/_tasks/integration/backup/postgresql.py
+++ b/apps/_tasks/integration/backup/postgresql.py
@@ -7,6 +7,11 @@ from apps._tasks.helper.tasks import delete_from_disk
 from apps.api.v1.utils.api_helpers import bs_decrypt, aws_s3_upload_log_file, check_error
 from apps.api.v1.utils.api_helpers import zipdir, mkdir_p
 from apps.console.utils.models import UtilBackup
+from apps._tasks.integration.backup._sanitize import (
+    safe_token,
+    safe_password,
+    safe_options,
+)
 from os import path
 
 
@@ -34,7 +39,7 @@ def snapshot_postgresql(backup):
 
     try:
         if node.database.option_postgres:
-            option_postgres = f"-w {node.database.option_postgres}"
+            option_postgres = f"-w {safe_options(node.database.option_postgres, 'option_postgres')}"
         else:
             option_postgres = "-w --clean"
 
@@ -51,6 +56,18 @@ def snapshot_postgresql(backup):
         log_file.write(f"Integration Validation: Passed \n")
 
         database_version_path = node.connection.auth_database.bin_path()
+
+        # Reject command-injection / path-traversal payloads in the user-supplied
+        # connection fields before they are interpolated into the dump commands below.
+        safe_token(node.connection.auth_database.host, "host")
+        safe_token(node.connection.auth_database.port, "port")
+        safe_token(node.connection.auth_database.database_name, "database_name")
+        safe_token(bs_decrypt(node.connection.auth_database.username, encryption_key), "username")
+        safe_password(bs_decrypt(node.connection.auth_database.password, encryption_key), "password")
+        for _name in (node.database.databases or []):
+            safe_token(_name, "databases")
+        for _name in (node.database.tables or []):
+            safe_token(_name, "tables")
 
         if (
                 node.connection.auth_database.use_public_key
@@ -106,6 +123,7 @@ def snapshot_postgresql(backup):
                         databases.append(database_name)
 
                 for database in databases:
+                    safe_token(database, "database")
                     log_file.write(f"Found Database: {database} \n")
 
                     db_file = f"{local_dir}{database}.sql"

--- a/apps/_tasks/integration/backup/wordpress.py
+++ b/apps/_tasks/integration/backup/wordpress.py
@@ -5,7 +5,7 @@ from sentry_sdk import capture_exception
 import hashlib
 from apps._tasks.exceptions import NodeBackupFailedError
 from apps.api.v1.utils.api_helpers import check_string_in_file, aws_s3_upload_log_file
-from apps.api.v1.utils.api_helpers import mkdir_p
+from apps.api.v1.utils.api_helpers import mkdir_p, safe_basename
 from apps._tasks.helper.tasks import delete_from_disk
 from apps.console.utils.models import UtilBackup
 import time
@@ -86,7 +86,9 @@ def snapshot_wordpress(backup):
                     verify=False,
                     timeout=180,
                 )
-                updraft_log_file = result.json().get("log_file")
+                # Strip any directory component the remote site may include so it cannot
+                # be used to write/read outside the backup's _storage directory.
+                updraft_log_file = safe_basename(result.json().get("log_file"))
                 status = result.json().get("status")
 
                 msg = f"Check counter no {check_counter}. Backup status: {status} Logfile: {updraft_log_file}."
@@ -191,8 +193,9 @@ def snapshot_wordpress(backup):
                     allow_redirects=True,
                     stream=True,
                 )
-                # save downloaded file
-                backup_file_alt = backup_file.replace(backup.uuid_str, md5_code)
+                # save downloaded file (strip any directory component the remote site may
+                # include so the write stays inside the backup's _storage directory)
+                backup_file_alt = safe_basename(backup_file.replace(backup.uuid_str, md5_code))
 
                 '''
                 Sometime .gz files are sent by server as text. So we will add .zip so we can download it.

--- a/apps/api/v1/auth/serializers.py
+++ b/apps/api/v1/auth/serializers.py
@@ -12,28 +12,24 @@ class APIAuthLoginSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True, allow_blank=False)
     password = serializers.CharField(max_length=128, required=True)
 
-    @staticmethod
-    def validate_email(value):
-        if not CoreMember.objects.filter(user__email__iexact=value).exists():
-            raise serializers.ValidationError("Email not found")
-        return value
-
     def validate_password(self, value):
+        # Use a single generic error for both unknown-email and wrong-password so the
+        # endpoint does not let an attacker enumerate which emails are registered.
         initial_values = self.get_initial()
+        email = initial_values.get("email")
 
-        email = initial_values["email"]
+        generic_error = serializers.ValidationError("wrong email & password combination")
 
-        if CoreMember.objects.filter(user__email__iexact=email).exists():
-            member = CoreMember.objects.get(user__email__iexact=email)
-            user = member.user
+        member = CoreMember.objects.filter(user__email__iexact=email).first()
+        if not member:
+            raise generic_error
 
-            if not authenticate(username=user.username, password=value):
-                raise serializers.ValidationError("wrong email & password combination")
-            else:
-                user = authenticate(username=user.username, password=value)
-                self.member = user.member
+        user = authenticate(username=member.user.username, password=value)
+        if not user:
+            raise generic_error
 
-            return value
+        self.member = user.member
+        return value
 
 
 class APIAuthResetSerializer(serializers.Serializer):
@@ -47,10 +43,10 @@ class APIAuthResetSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True, allow_blank=False)
 
     def validate_email(self, value):
-        if CoreMember.objects.filter(user__email__iexact=value).exists() is False:
-            raise serializers.ValidationError("email doesn't exists")
-        elif CoreMember.objects.filter(user__email__iexact=value).exists() is True:
-            self.member = CoreMember.objects.get(user__email__iexact=value)
+        # Always validate successfully; whether a reset email is actually sent depends on
+        # whether the address exists, but the response must not reveal that (account
+        # enumeration). The view only sends when self.member is set.
+        self.member = CoreMember.objects.filter(user__email__iexact=value).first()
         return value
 
 
@@ -62,18 +58,27 @@ class APIAuthResetPatchSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         pass
 
-    password = serializers.CharField(min_length=4, required=True, allow_blank=False)
+    password = serializers.CharField(min_length=8, required=True, allow_blank=False)
     password_confirm = serializers.CharField(
-        min_length=4, required=True, allow_blank=False
+        min_length=8, required=True, allow_blank=False
     )
     password_token = serializers.CharField(required=True, allow_blank=False)
 
     def validate_password(self, value):
+        from django.contrib.auth.password_validation import validate_password
+        from django.core.exceptions import ValidationError as DjangoValidationError
 
         initial_values = self.get_initial()
 
         if value != initial_values["password_confirm"]:
             raise serializers.ValidationError("password do not match")
+
+        # Apply Django's configured AUTH_PASSWORD_VALIDATORS (length, common, numeric, ...);
+        # set_password() does not enforce these on its own.
+        try:
+            validate_password(value)
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(list(e.messages))
         return value
 
     def validate_password_confirm(self, value):
@@ -85,8 +90,10 @@ class APIAuthResetPatchSerializer(serializers.Serializer):
         return value
 
     def validate_password_token(self, value):
-        if CoreMember.objects.filter(password_reset_token=value).exists() is False:
-            raise serializers.ValidationError("wrong password reset token")
-        elif CoreMember.objects.filter(password_reset_token=value).exists() is True:
-            self.member = CoreMember.objects.get(password_reset_token=value)
-        return value
+        # Resolve the token without leaking which tokens exist, then enforce
+        # constant-time match + expiry via the model helper.
+        for member in CoreMember.objects.filter(password_reset_token=value):
+            if member.password_reset_token_is_valid(value):
+                self.member = member
+                return value
+        raise serializers.ValidationError("Invalid or expired password reset token")

--- a/apps/api/v1/auth/views.py
+++ b/apps/api/v1/auth/views.py
@@ -70,7 +70,10 @@ class APIAuthReset(APIView):
         serializer = APIAuthResetSerializer(data=self.request.data, context={"request": request})
         if serializer.is_valid():
             member = serializer.member
-            member.send_password_reset()
+            # member is None when the email is not registered; respond identically either
+            # way so the endpoint cannot be used to enumerate accounts.
+            if member:
+                member.send_password_reset()
             content = {"password_reset_email": True}
         else:
             raise ExceptionDefault(detail=serializer.errors)
@@ -85,6 +88,7 @@ class APIAuthReset(APIView):
             member.user.set_password(password)
             member.user.save()
             member.password_reset_token = None
+            member.password_reset_token_created = None
             member.save()
             content = {"password_reset": True}
         else:

--- a/apps/api/v1/callback/views.py
+++ b/apps/api/v1/callback/views.py
@@ -583,7 +583,17 @@ class APICallbackDigitalOcean(APIView):
                 # if account_req.status_code == 200:
                 #     do_account = account_req.json()
 
-                member = CoreMember.objects.get(id=state)
+                # The OAuth `state` is attacker-controllable, so never trust it to select
+                # the member/account the new credentials are attached to. Bind the result
+                # to the authenticated session and reject a state that doesn't match it.
+                member = request.user.member
+                if state and str(state) != str(member.id):
+                    messages.add_message(
+                        request,
+                        messages.ERROR,
+                        "Unable to connect account due to a verification mismatch. Please try again.",
+                    )
+                    return redirect("console:setup:integration_open", integration_code="digitalocean")
                 account = member.get_current_account()
                 encryption_key = account.get_encryption_key()
 

--- a/apps/api/v1/utils/api_authentication.py
+++ b/apps/api/v1/utils/api_authentication.py
@@ -5,9 +5,22 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 
-class CsrfExemptSessionAuthentication(SessionAuthentication):
-    def enforce_csrf(self, request):
-        return
+class ConsoleSessionAuthentication(SessionAuthentication):
+    """Standard DRF SessionAuthentication.
+
+    Cookie-authenticated requests are CSRF-protected (the previous
+    ``CsrfExemptSessionAuthentication`` disabled this, leaving every state-changing API
+    endpoint open to cross-site request forgery). The console front-end sends the CSRF
+    token via the ``X-CSRFToken`` header (see the global fetch wrapper in the base
+    template); token-authenticated API clients are unaffected because CSRF is only
+    enforced for the session authenticator.
+    """
+    pass
+
+
+# Backwards-compatible alias for any external import; this name no longer implies a CSRF
+# exemption.
+CsrfExemptSessionAuthentication = ConsoleSessionAuthentication
 
 
 class CustomTokenAuthentication(TokenAuthentication):

--- a/apps/api/v1/utils/api_helpers.py
+++ b/apps/api/v1/utils/api_helpers.py
@@ -247,31 +247,6 @@ def sizify(value):
     return f"{str(round(value, 2))} {ext}"
 
 
-def get_coordinates(query, from_sensor=False):
-    import urllib
-    import json
-
-    googleGeocodeUrl = "https://maps.googleapis.com/maps/api/geocode/json?"
-
-    query = query.encode("utf-8")
-    params = {
-        "address": query,
-        "key": "AIzaSyBvj20P6aP-DowWicCrp3ON-ZzSyXYPOOM",
-        "sensor": "true" if from_sensor else "false",
-    }
-    url = googleGeocodeUrl + urllib.urlencode(params)
-    json_response = urllib.urlopen(url)
-    response = json.loads(json_response.read())
-    if response["results"]:
-        location = response["results"][0]["geometry"]["location"]
-        latitude, longitude = location["lat"], location["lng"]
-        print(query, latitude, longitude)
-    else:
-        latitude, longitude = None, None
-        print(query, "<no results>")
-    return latitude, longitude
-
-
 def color_variant(hex_color, brightness_offset=1):
     """takes a color like #87c95f and produces a lighter or darker variant"""
     if len(hex_color) != 7:
@@ -798,6 +773,58 @@ def make_digest(message, key):
     # print(signature2)
 
     return str(signature2, "UTF-8")
+
+
+def assert_url_not_metadata(url, field="url"):
+    """Block SSRF to cloud metadata / loopback / link-local from a user-supplied URL.
+
+    This is intentionally narrow: a self-hosted install may legitimately back up a
+    WordPress site on a private LAN (RFC1918), so private ranges are allowed. What is
+    never a legitimate backup target is the loopback interface or the link-local range
+    (169.254.0.0/16 / fe80::/10) that fronts the cloud instance metadata service
+    (169.254.169.254, the GCP metadata host, etc.), so those are refused.
+    """
+    import ipaddress
+    import socket
+    from urllib.parse import urlparse
+
+    host = (urlparse(url).hostname or "").strip()
+    if not host:
+        raise ValueError(f"Invalid {field}: no host.")
+
+    # Block the well-known metadata hostname directly (it may not resolve to a literal).
+    if host.lower() in ("metadata.google.internal", "metadata"):
+        raise ValueError(f"Refusing to connect to metadata host in {field}.")
+
+    addresses = set()
+    try:
+        addresses.add(ipaddress.ip_address(host))  # url used a literal IP
+    except ValueError:
+        try:
+            for res in socket.getaddrinfo(host, None):
+                addresses.add(ipaddress.ip_address(res[4][0]))
+        except Exception:
+            # If it cannot be resolved here, let the actual request fail normally.
+            return url
+
+    for ip in addresses:
+        if ip.is_loopback or ip.is_link_local:
+            raise ValueError(
+                f"Refusing to connect to a loopback/link-local address in {field}."
+            )
+    return url
+
+
+def safe_basename(name, fallback="file"):
+    """Return a path-traversal-safe filename component from an untrusted value.
+
+    Strips any directory component so a value like ``../../etc/passwd`` returned by a
+    remote server cannot be used to write outside the intended directory.
+    """
+    base = os.path.basename(str(name or "").replace("\\", "/").strip())
+    if base in ("", ".", ".."):
+        return fallback
+    return base
 
 
 def check_error(error_text):

--- a/apps/console/_templates/console/_master.html
+++ b/apps/console/_templates/console/_master.html
@@ -13,6 +13,34 @@
     <link href="https://vjs.zencdn.net/8.10.0/video-js.css" rel="stylesheet"/>
 </head>
 <body class="h-full{% block page_class %}{% endblock %}">
+{% csrf_token %}
+<script>
+    // Attach Django's CSRF token to every same-origin state-changing fetch() so the
+    // session-authenticated API (now CSRF-protected) accepts console requests.
+    (function () {
+        function getCookie(name) {
+            const value = "; " + document.cookie;
+            const parts = value.split("; " + name + "=");
+            if (parts.length === 2) return parts.pop().split(";").shift();
+            return null;
+        }
+        const unsafe = /^(POST|PUT|PATCH|DELETE)$/i;
+        const origFetch = window.fetch;
+        window.fetch = function (input, init) {
+            init = init || {};
+            const method = (init.method || (typeof input !== "string" && input && input.method) || "GET");
+            if (unsafe.test(method)) {
+                const token = getCookie("csrftoken");
+                if (token) {
+                    const headers = new Headers(init.headers || (typeof input !== "string" && input && input.headers) || {});
+                    if (!headers.has("X-CSRFToken")) headers.set("X-CSRFToken", token);
+                    init.headers = headers;
+                }
+            }
+            return origFetch.call(this, input, init);
+        };
+    })();
+</script>
 <div x-data="{ sideBar: false }">
     {% include "_sidebar.html" %}
     <div class="lg:pl-72">

--- a/apps/console/connection/models.py
+++ b/apps/console/connection/models.py
@@ -2458,6 +2458,11 @@ class CoreAuthWordPress(TimeStampedModel):
             url = self.url
             key = self.key
 
+        # Block SSRF to cloud metadata / loopback / link-local before any request is made.
+        from apps.api.v1.utils.api_helpers import assert_url_not_metadata
+
+        assert_url_not_metadata(url, "WordPress url")
+
         client = self.get_client()
 
         # adapter = SSLAdapter(ssl.PROTOCOL_TLSv1_2)

--- a/apps/console/member/models.py
+++ b/apps/console/member/models.py
@@ -12,6 +12,7 @@ class CoreMember(TimeStampedModel):
     accounts = models.ManyToManyField(CoreAccount, related_name='members', through='CoreMemberAccount')
     timezone = models.CharField(max_length=64, default="UTC")
     password_reset_token = models.CharField(null=True, max_length=255, blank=True)
+    password_reset_token_created = models.DateTimeField(null=True, blank=True, editable=False)
 
     class Meta:
         db_table = 'core_member'
@@ -104,12 +105,39 @@ class CoreMember(TimeStampedModel):
     def is_primary_account(self):
         return self.memberships.filter(primary=True, account=self.get_current_account()).exists()
 
+    # Password reset tokens expire this many hours after they are issued.
+    PASSWORD_RESET_TOKEN_TTL_HOURS = 1
+
+    @staticmethod
+    def generate_password_reset_token():
+        # Cryptographically strong, single-use, ~256-bit token (replaces the old
+        # 32-bit uuid4()[:8] token which was brute-forceable).
+        import secrets
+
+        return secrets.token_urlsafe(32)
+
+    def password_reset_token_is_valid(self, token):
+        """A token matches only if it is non-empty, equal (constant-time) and unexpired."""
+        import secrets
+        from django.utils import timezone
+        from datetime import timedelta
+
+        if not token or not self.password_reset_token:
+            return False
+        if not secrets.compare_digest(str(self.password_reset_token), str(token)):
+            return False
+        if not self.password_reset_token_created:
+            return False
+        expires_at = self.password_reset_token_created + timedelta(hours=self.PASSWORD_RESET_TOKEN_TTL_HOURS)
+        return timezone.now() <= expires_at
+
     @property
     def get_password_reset_link(self):
-        password_reset_token = str(uuid.uuid4()).split("-")[0]
+        from django.utils import timezone
 
         if not self.password_reset_token:
-            self.password_reset_token = password_reset_token
+            self.password_reset_token = self.generate_password_reset_token()
+            self.password_reset_token_created = timezone.now()
             self.save()
 
         return f"{settings.APP_URL}/reset/{self.password_reset_token}/"
@@ -119,10 +147,10 @@ class CoreMember(TimeStampedModel):
 
     def send_password_reset(self, next_url=None):
         from apps.console.notification.models import CoreNotificationLogEmail
+        from django.utils import timezone
 
-        password_reset_token = str(uuid.uuid4()).split("-")[0]
-
-        self.password_reset_token = password_reset_token
+        self.password_reset_token = self.generate_password_reset_token()
+        self.password_reset_token_created = timezone.now()
         self.save()
 
         email_notification = CoreNotificationLogEmail()

--- a/backupsheep/settings.py
+++ b/backupsheep/settings.py
@@ -155,12 +155,14 @@ REST_FRAMEWORK = {
         "rest_framework.parsers.MultiPartParser",
     ),
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "apps.api.v1.utils.api_authentication.CsrfExemptSessionAuthentication",
+        "apps.api.v1.utils.api_authentication.ConsoleSessionAuthentication",
         "apps.api.v1.utils.api_authentication.CustomTokenAuthentication",
     ),
+    # The browsable API UI is handy in development but exposes a self-documenting,
+    # form-driven interface in production, so only enable it when DEBUG is on.
     "DEFAULT_RENDERER_CLASSES": (
-        "rest_framework.renderers.JSONRenderer",
-        "rest_framework.renderers.BrowsableAPIRenderer",
+        ("rest_framework.renderers.JSONRenderer",)
+        + (("rest_framework.renderers.BrowsableAPIRenderer",) if DEBUG else tuple())
     ),
     "EXCEPTION_HANDLER": "rest_framework.views.exception_handler",
     "DEFAULT_FILTER_BACKENDS": (


### PR DESCRIPTION
Addresses findings from the repository security review:

- Command injection / RCE (critical): the MySQL, MariaDB and PostgreSQL backup
  tasks interpolated unvalidated user-controlled connection/node fields (host,
  username, password, database/table names, dump options) into shell=True and
  ssh.exec_command command strings. Add apps/_tasks/integration/backup/_sanitize.py
  and validate these inputs before they reach the shell, rejecting shell
  metacharacters / path separators (and single quotes in passwords). Legitimate
  values pass unchanged.

- CSRF (high): the API used a SessionAuthentication subclass that disabled CSRF
  entirely, exposing every state-changing endpoint. Replace it with a standard
  CSRF-enforcing ConsoleSessionAuthentication and add a global fetch() wrapper in
  the console base template that sends the X-CSRFToken header.

- Password reset (high): tokens were the first 8 hex chars of a uuid4 (32 bits),
  never expired and bypassed password validators. Use secrets.token_urlsafe(32),
  add a token-created timestamp + 1h expiry with constant-time comparison, enforce
  AUTH_PASSWORD_VALIDATORS, and raise the minimum length.

- SSRF (high): block cloud-metadata / loopback / link-local targets in the
  user-supplied WordPress URL (private LAN ranges remain allowed for self-hosting).

- Path traversal (medium): strip directory components from remote-supplied
  WordPress filenames before writing into _storage.

- OAuth state (medium): bind the DigitalOcean callback to the authenticated member
  instead of trusting the attacker-controllable state parameter.

- Account enumeration (medium): use a single generic error on login and respond
  identically on password reset regardless of whether the email exists.

- Hardcoded Google API key removed (dead get_coordinates helper).

- BrowsableAPIRenderer is now enabled only when DEBUG is on.