### PR TITLE
security: validate login 'next' redirect target against the host

### DIFF
--- a/apps/console/auth/views.py
+++ b/apps/console/auth/views.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.views import *
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import TemplateView
 
 from apps.console.member.models import CoreMember
@@ -16,7 +17,16 @@ class LoginView(TemplateView):
 
     def get(self, request, *args, **kwargs):
         context = self.get_context_data(**kwargs)
-        request.session["next"] = request.GET.get("next", None)
+        # Only honor same-host redirect targets. After login the browser is sent
+        # to this value verbatim (window.location = json.next), so accepting an
+        # arbitrary absolute URL here turns the login page into an open redirect
+        # for phishing.
+        next_url = request.GET.get("next", None)
+        if next_url and not url_has_allowed_host_and_scheme(
+            next_url, allowed_hosts={request.get_host()}, require_https=False
+        ):
+            next_url = None
+        request.session["next"] = next_url
         return self.render_to_response(context)
 
 


### PR DESCRIPTION
## Summary
Fixes an **open redirect** on the login page (finding E2 of the security review).

`LoginView.get` stored the `?next=` query parameter in the session unvalidated, and after a successful login the template redirected the browser to it verbatim (`window.location = json.next` in `login.html`). An attacker could send staff a link to the **real** console with `?next=https://attacker-clone`; after a legitimate login, the victim is bounced to a phishing clone that asks them to "log in again."

## Fix
`next` is now accepted only if it passes Django's `url_has_allowed_host_and_scheme` against the current host; anything else is dropped. Relative paths (the normal in-app flow) keep working.

## Verification (live-fire, local lab)
- `/login/?next=https://evil.example/console-clone` → login → response `next: null` (**blocked**)
- `/login/?next=/console/backups/` → login → response `next: "/console/backups/"` (**preserved**)