### PR TITLE
security: re-validate redirect targets in WordPress backup HTTP calls

### DIFF
--- a/apps/_tasks/integration/backup/wordpress.py
+++ b/apps/_tasks/integration/backup/wordpress.py
@@ -5,7 +5,7 @@ from sentry_sdk import capture_exception
 import hashlib
 from apps._tasks.exceptions import NodeBackupFailedError
 from apps.api.v1.utils.api_helpers import check_string_in_file, aws_s3_upload_log_file
-from apps.api.v1.utils.api_helpers import mkdir_p, safe_basename
+from apps.api.v1.utils.api_helpers import mkdir_p, safe_basename, ssrf_safe_get
 from apps._tasks.helper.tasks import delete_from_disk
 from apps.console.utils.models import UtilBackup
 import time
@@ -56,7 +56,7 @@ def snapshot_wordpress(backup):
             log_file.write(f"Tigger Backup: {url} \n")
 
             # We don't need to wait for this
-            requests.get(
+            ssrf_safe_get(
                 url,
                 auth=auth,
                 headers=client,
@@ -79,7 +79,7 @@ def snapshot_wordpress(backup):
                       f"&key={node.connection.auth_wordpress.key}" \
                       f"&t={time.time()}"
                 log_file.write(f"Check backup status: {url} \n")
-                result = requests.get(
+                result = ssrf_safe_get(
                     url,
                     auth=auth,
                     headers=client,
@@ -106,12 +106,11 @@ def snapshot_wordpress(backup):
                           f"&key={node.connection.auth_wordpress.key}" \
                           f"&t={time.time()}"
                     log_file.write(f"Download updraft backup log: {url} \n")
-                    r = requests.get(
+                    r = ssrf_safe_get(
                         url,
                         auth=auth,
                         headers=client,
                         verify=False,
-                        allow_redirects=True,
                         stream=True,
                     )
                     # save downloaded log file
@@ -160,7 +159,7 @@ def snapshot_wordpress(backup):
 
         log_file.write(f"Get list of backup files: {url} \n")
 
-        result = requests.get(
+        result = ssrf_safe_get(
             url,
             auth=auth,
             headers=client,
@@ -185,12 +184,11 @@ def snapshot_wordpress(backup):
                 msg = f"Downloading file: {backup_file} using URL {url}"
                 log_file.write(f"Downloading file: {backup_file} using URL {url} \n")
 
-                r = requests.get(
+                r = ssrf_safe_get(
                     url,
                     auth=auth,
                     headers=client,
                     verify=False,
-                    allow_redirects=True,
                     stream=True,
                 )
                 # save downloaded file (strip any directory component the remote site may
@@ -224,13 +222,12 @@ def snapshot_wordpress(backup):
 
                 log_file.write(f"Delete file: {url} \n")
 
-                r_delete = requests.get(
+                r_delete = ssrf_safe_get(
                     url,
                     auth=auth,
                     headers=client,
                     verify=False,
-                    allow_redirects=True,
-                )
+                    )
 
                 if r_delete.status_code == 200:
                     if r_delete.json().get("deleted"):
@@ -259,7 +256,7 @@ def snapshot_wordpress(backup):
         f"/?rest_route=/backupsheep/updraftplus/rebuild_history"
         f"&t={time.time()}"
         f"&key={node.connection.auth_wordpress.key}"
-        requests.get(
+        ssrf_safe_get(
             url,
             auth=auth,
             headers=client,

--- a/apps/api/v1/utils/api_helpers.py
+++ b/apps/api/v1/utils/api_helpers.py
@@ -827,10 +827,46 @@ def safe_basename(name, fallback="file"):
     return base
 
 
+def ssrf_safe_get(url, max_redirects=5, **kwargs):
+    """requests.get() that re-validates every redirect target with assert_url_not_metadata.
+
+    requests follows redirects automatically WITHOUT re-checking the destination, so a
+    compromised or malicious backup source could bounce the worker at the cloud metadata
+    service (169.254.169.254), loopback, or other internal addresses — and the response
+    body would be saved into the backup archive, exfiltrating internal data to whoever
+    downloads that backup (verified end-to-end against the WordPress download flow:
+    instance-role credentials landed in the attacker-owned backup archive).
+
+    Redirects are followed manually here; each Location is validated before use, and
+    credentials are not forwarded across hosts.
+    """
+    import requests
+    from urllib.parse import urljoin, urlparse
+
+    kwargs["allow_redirects"] = False
+    current_url = url
+    for _ in range(max_redirects + 1):
+        response = requests.get(current_url, **kwargs)
+        if not (response.is_redirect or response.is_permanent_redirect):
+            return response
+        location = response.headers.get("Location")
+        if not location:
+            return response
+        next_url = urljoin(current_url, location)
+        assert_url_not_metadata(next_url, field="redirect target")
+        if urlparse(next_url).netloc.lower() != urlparse(current_url).netloc.lower():
+            # Never forward credentials to a different host.
+            kwargs.pop("auth", None)
+            headers = dict(kwargs.get("headers") or {})
+            headers.pop("Authorization", None)
+            kwargs["headers"] = headers
+        current_url = next_url
+    raise ValueError(f"Too many redirects while fetching {url!r}.")
+
+
 def check_error(error_text):
     valid_error = None
     try:
         valid_error = len(error_text.strip()) > 0
     except Exception:
         pass
-    return valid_error

--- a/apps/api/v1/utils/api_helpers.py
+++ b/apps/api/v1/utils/api_helpers.py
@@ -870,3 +870,4 @@ def check_error(error_text):
         valid_error = len(error_text.strip()) > 0
     except Exception:
         pass
+    return valid_error


### PR DESCRIPTION
## Summary
Fixes **SSRF via redirect → cloud credential theft** in the WordPress backup flow (finding E4 of the security review).

`assert_url_not_metadata()` guarded only the connection URL at setup time. But every WordPress plugin call used `requests.get(..., allow_redirects=True)`, and requests never re-checks the redirect destination. A malicious/compromised WordPress site (or a network MITM, since these calls also pass `verify=False`) could 302 the worker's "backup file" downloads at `http://169.254.169.254/...` or any loopback service; the response body was saved into the backup archive and downloadable by the attacker.

## Verified exploit (before this fix)
Attacker-controlled "WordPress site" (public IP, passes the setup-time guard) → 302 redirect on `/download` → worker fetched the fake metadata service **3 times** → instance-role credentials (`AccessKeyId`/`SecretAccessKey`/`Token`) landed inside the attacker's own downloadable backup archive.

## Fix
New `ssrf_safe_get()` in `apps/api/v1/utils/api_helpers.py`: follows redirects manually (max 5), runs `assert_url_not_metadata` on **every** Location target, and strips `auth`/`Authorization` on cross-host redirects so credentials never leak to a different host. All seven WordPress plugin call sites in `wordpress.py` now use it.

## Verification (live-fire, local lab)
Same attack against the patched worker: the download is refused — backup log records
`Error: Refusing to connect to a loopback/link-local address in redirect target.`
and the fake metadata service receives **zero** hits. The backup fails safely.

## Deliberately out of scope (follow-ups)
- The same helper should be applied to the WordPress calls in `console/backup/models.py` and `console/connection/models.py` (delete/history/validate flows).
- `verify=False` should become an explicit per-connection "allow self-signed" option rather than unconditional.
- On AWS, enforce IMDSv2 on hosts running workers (defense in depth).