### PR TITLE
security: rate-limit login and password-reset endpoints

### DIFF
--- a/apps/api/v1/auth/views.py
+++ b/apps/api/v1/auth/views.py
@@ -4,10 +4,12 @@ from rest_framework.views import APIView
 from .serializers import *
 from django.contrib.auth import login, logout
 from ..utils.api_exceptions import ExceptionDefault
+from ..utils.api_throttles import LoginRateThrottle, PasswordResetRateThrottle
 
 
 class APIAuthLogin(APIView):
     permission_classes = ()
+    throttle_classes = [LoginRateThrottle]
 
     def post(self, request):
         serializer = APIAuthLoginSerializer(data=self.request.data, context={"request": request})
@@ -65,6 +67,7 @@ class APIAuthLogout(APIView):
 
 class APIAuthReset(APIView):
     permission_classes = ()
+    throttle_classes = [PasswordResetRateThrottle]
 
     def post(self, request):
         serializer = APIAuthResetSerializer(data=self.request.data, context={"request": request})

--- a/apps/api/v1/utils/api_throttles.py
+++ b/apps/api/v1/utils/api_throttles.py
@@ -1,0 +1,22 @@
+"""Rate throttles for unauthenticated, credential-bearing endpoints.
+
+DRF's cache-backed throttle state uses the default cache (the database cache in
+this project), so no extra infrastructure is required. Clients are identified by
+IP (REMOTE_ADDR). If gunicorn runs behind a reverse proxy, set
+REST_FRAMEWORK["NUM_PROXIES"] = 1 so DRF honors X-Forwarded-For — only when
+requests can ONLY arrive via that proxy, otherwise the header is spoofable.
+"""
+
+from rest_framework.throttling import AnonRateThrottle
+
+
+class LoginRateThrottle(AnonRateThrottle):
+    """Brute-force / credential-stuffing guard for the login endpoint."""
+
+    rate = "5/minute"
+
+
+class PasswordResetRateThrottle(AnonRateThrottle):
+    """Reset-email spam and token-guessing guard for the password reset endpoint."""
+
+    rate = "3/minute"


### PR DESCRIPTION
## Summary
Adds **rate limiting to the anonymous credential endpoints** (finding E5 of the security review).

`/api/v1/auth/login` and `/api/v1/auth/reset` had `permission_classes = ()` and no throttling anywhere in the project — unlimited online password guessing, credential stuffing, and reset-email spam.

## Verified exploit (before this fix)
60 consecutive failed logins answered in 51.8s with plain 400s — no 429, no lockout, no delay; attempt #61 with the right password succeeded.

## Fix
New `apps/api/v1/utils/api_throttles.py`:
- `LoginRateThrottle` — 5 req/min per IP on login
- `PasswordResetRateThrottle` — 3 req/min per IP on reset

Both are DRF `AnonRateThrottle` subclasses with hardcoded rates, so **no settings change is required**; throttle state lives in the existing database cache. Deployments behind a reverse proxy should set `REST_FRAMEWORK["NUM_PROXIES"] = 1` (noted in the module docstring).

## Verification (live-fire, local lab)
8 rapid login attempts against the patched app: `400 × 5` then `429, 429, 429` with `Request was throttled. Expected available in N seconds.`