### PR TITLE
Harden Docker supply chain and default ALLOWED_HOSTS

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -10,8 +10,10 @@ DJANGO_SERVER='prod'
 # debug mode, which leaks tracebacks/settings on errors — never do that on a public host.
 DJANGO_DEBUG=false
 # Public host(s) this install answers on. Use a real hostname in production (a comma-
-# separated list is allowed, e.g. "backup.example.com,www.example.com"). '*' = any host.
-DJANGO_ALLOWED_HOSTS='*'
+# separated list is allowed, e.g. "backup.example.com,www.example.com"). WARNING: setting
+# this to '*' disables Django's Host-header validation (host-header injection / cache
+# poisoning / password-reset poisoning). Only use '*' behind a proxy that sets Host.
+DJANGO_ALLOWED_HOSTS='localhost,127.0.0.1'
 # CHANGE THIS to a long random string and keep it STABLE. It signs sessions/tokens and
 # derives the key that encrypts stored email credentials — rotating it logs everyone out
 # and makes saved email creds undecryptable. Generate one with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN apt-get update \
     && apt-get -y install libncurses-dev libgnutls28-dev libexpat1-dev  pkg-config libreadline-dev  zlib1g-dev libssl-dev \
     && apt-get -y install software-properties-common tree libfreetype6-dev \
     && apt-get -y install tzdata \
-    && wget http://lftp.yar.ru/ftp/lftp-4.9.2.tar.gz \
-    && tar -xvf lftp-4.9.2.tar.gz && cd lftp-4.9.2 && ./configure && make install \
+    && apt-get -y install lftp \
     && pip install psycopg2
 
 # PostgreSQL client tools (pg_dump / psql / pg_restore) for versions 14-18 from the


### PR DESCRIPTION
## Summary

Two hardening fixes for fresh self-hosted installs.

## 1. Dockerfile — lftp over plain HTTP, no integrity check

**Before:** the image downloaded `lftp-4.9.2.tar.gz` over **plain HTTP** from `lftp.yar.ru` and compiled it with no checksum or signature verification:

```dockerfile
&& wget http://lftp.yar.ru/ftp/lftp-4.9.2.tar.gz \
&& tar -xvf lftp-4.9.2.tar.gz && cd lftp-4.9.2 && ./configure && make install \
```

A MITM on the build network (or a compromised mirror) would inject arbitrary code into every backup image — and this image handles every stored credential.

**After:** install lftp from apt. Debian bookworm (the base image) ships the **same lftp 4.9.2**, fetched over HTTPS from signed repositories:

```dockerfile
&& apt-get -y install lftp \
```

This also drops the source-build toolchain requirement for that step and speeds up the build.

## 2. .env_sample — `DJANGO_ALLOWED_HOSTS='*'` default

The sample config shipped `DJANGO_ALLOWED_HOSTS='*'`, which disables Django's Host-header validation — enabling host-header injection, cache poisoning, and password-reset link poisoning on installs that copy the sample verbatim.

The default is now `localhost,127.0.0.1` (works out of the box for the local docker-compose stack) with a warning comment explaining when `*` is and isn't acceptable.

## Verification

- Push fidelity verified byte-for-byte via the GitHub API.
- `lftp --version` in a bookworm container confirms apt ships 4.9.2, same as the removed source build.