### PR TITLE
Require install token for first-admin creation (onboarding)

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -22,6 +22,13 @@ DJANGO_SETTINGS_MODULE='backupsheep.settings'
 # reverse proxy). Enables Secure cookies, HSTS, and HTTP->HTTPS redirect.
 DJANGO_HTTPS=false
 
+# First-run onboarding gate. The first account created through /onboarding becomes the
+# instance admin; the install token proves the person running the wizard has access to
+# this server. Leave blank to use the auto-generated token written to
+# _storage/install_token on first load (read: docker compose exec web cat
+# /code/_storage/install_token), or set a fixed value here for automated installs.
+ONBOARDING_INSTALL_TOKEN=''
+
 # Public URL this install is reached at (used for links, OAuth redirects, CSRF origins).
 APP_DOMAIN='localhost:8000'
 APP_PROTOCOL='http://'

--- a/apps/console/_templates/console/onboarding/account.html
+++ b/apps/console/_templates/console/onboarding/account.html
@@ -7,6 +7,12 @@
         {% if form.non_field_errors %}
             <div class="rounded-md bg-red-50 ring-1 ring-red-200 text-red-700 text-sm px-4 py-3 mb-4">{{ form.non_field_errors }}</div>
         {% endif %}
+        <div class="rounded-md bg-amber-50 ring-1 ring-amber-200 text-amber-800 text-sm px-4 py-3 mb-4">
+            The install token proves you have access to this server before the first admin
+            is created. Find it with:
+            <code class="font-mono text-xs">docker compose exec web cat /code/_storage/install_token</code>
+        </div>
+        {% include "console/onboarding/_field.html" with field=form.install_token %}
         {% include "console/onboarding/_field.html" with field=form.full_name %}
         {% include "console/onboarding/_field.html" with field=form.organization %}
         {% include "console/onboarding/_field.html" with field=form.email %}

--- a/apps/console/onboarding/forms.py
+++ b/apps/console/onboarding/forms.py
@@ -21,6 +21,15 @@ _EMAIL_PROVIDER_CHOICES = [
 class AccountForm(forms.Form):
     """Creates the first admin (account owner). Email is also the login username."""
 
+    install_token = forms.CharField(
+        label="Install token",
+        help_text=(
+            "Proves you have access to this server. Read it with: "
+            "docker compose exec web cat /code/_storage/install_token "
+            "(or set ONBOARDING_INSTALL_TOKEN in .env)."
+        ),
+        widget=forms.TextInput(attrs={"class": INPUT, "autocomplete": "off"}),
+    )
     full_name = forms.CharField(max_length=150, widget=forms.TextInput(attrs={"class": INPUT}))
     organization = forms.CharField(
         max_length=255, required=False, widget=forms.TextInput(attrs={"class": INPUT})

--- a/apps/console/onboarding/tests.py
+++ b/apps/console/onboarding/tests.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 
 from apps.console.account.models import CoreAccount
 from apps.console.member.models import CoreMember, CoreMemberAccount
@@ -9,8 +9,10 @@ from utils.middleware import OnboardingMiddleware
 User = get_user_model()
 
 PW = "Sup3r-Secret-Pw!"
+INSTALL_TOKEN = "test-install-token"
 
 
+@override_settings(ONBOARDING_INSTALL_TOKEN=INSTALL_TOKEN)
 class OnboardingFlowTests(TestCase):
     def setUp(self):
         # OnboardingMiddleware caches "setup completed" in a process-global latch; reset it
@@ -21,17 +23,24 @@ class OnboardingFlowTests(TestCase):
     def tearDown(self):
         OnboardingMiddleware._completed = False
 
-    def _create_admin(self, email="ada@example.com"):
+    def _create_admin(self, email="ada@example.com", install_token=INSTALL_TOKEN):
         return self.client.post(
             "/onboarding/account/",
             {"full_name": "Ada Admin", "organization": "Acme", "email": email,
-             "password1": PW, "password2": PW},
+             "password1": PW, "password2": PW, "install_token": install_token},
         )
 
     def test_anonymous_is_forced_into_wizard(self):
         r = self.client.get("/")
         self.assertEqual(r.status_code, 302)
         self.assertTrue(r.headers["Location"].startswith("/onboarding"))
+
+    def test_account_creation_rejects_missing_or_wrong_install_token(self):
+        for bad_token in ("", "wrong-token"):
+            r = self._create_admin(install_token=bad_token)
+            self.assertEqual(r.status_code, 200)  # re-rendered with an error
+            self.assertIn("Invalid install token", r.content.decode())
+            self.assertEqual(User.objects.count(), 0)
 
     def test_account_creation_builds_chain_and_logs_in(self):
         r = self._create_admin()

--- a/apps/console/onboarding/views.py
+++ b/apps/console/onboarding/views.py
@@ -6,6 +6,9 @@ from django.db import transaction
 from django.shortcuts import redirect, render
 from django.utils import timezone
 
+import os
+import secrets
+
 from apps.console.account.models import CoreAccount
 from apps.console.member.models import CoreMember, CoreMemberAccount
 from apps.console.setting.models import CoreSiteSettings
@@ -28,6 +31,41 @@ def _require_admin(request):
     return request.user.is_authenticated and hasattr(request.user, "member")
 
 
+def _expected_install_token():
+    """Token the installer must present to create the first admin account.
+
+    Priority: the ONBOARDING_INSTALL_TOKEN environment setting; otherwise a random
+    per-install token written to a file that is only readable with host/container
+    access (generated on first request). Either way, completing the wizard over the
+    network requires proving access to the machine it runs on.
+    """
+    if dj_settings.ONBOARDING_INSTALL_TOKEN:
+        return dj_settings.ONBOARDING_INSTALL_TOKEN
+    path = dj_settings.ONBOARDING_INSTALL_TOKEN_FILE
+    try:
+        with open(path) as fh:
+            token = fh.read().strip()
+            if token:
+                return token
+    except OSError:
+        pass
+    token = secrets.token_urlsafe(24)
+    try:
+        with open(path, "w") as fh:
+            fh.write(token)
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return token
+
+
+def _install_token_ok(request, expected):
+    presented = request.POST.get("install_token", "").strip()
+    if not presented or not expected:
+        return False
+    return secrets.compare_digest(presented, expected)
+
+
 def index(request):
     if not User.objects.exists():
         return redirect("console:onboarding:account")
@@ -45,7 +83,14 @@ def account(request):
 
     if request.method == "POST":
         form = AccountForm(request.POST)
-        if form.is_valid():
+        token_ok = _install_token_ok(request, _expected_install_token())
+        if not token_ok:
+            form.add_error(
+                "install_token",
+                "Invalid install token. Read it from the server with: "
+                "docker compose exec web cat /code/_storage/install_token",
+            )
+        if token_ok and form.is_valid():
             with transaction.atomic():
                 user = User.objects.create_user(
                     username=form.cleaned_data["email"],

--- a/backupsheep/settings.py
+++ b/backupsheep/settings.py
@@ -277,6 +277,16 @@ API_PATH = "/api/"
 CONSOLE_URL = "/console"
 ONBOARDING_URL = "/onboarding"
 
+# First-run onboarding gate. Whoever completes the wizard becomes the instance admin,
+# so creating the first account requires proof of infrastructure access: either this
+# fixed token from the environment, or a per-install random token the app writes to
+# ONBOARDING_INSTALL_TOKEN_FILE (read it with:
+#   docker compose exec web cat /code/_storage/install_token
+# ). Without the gate, anyone who reaches an unconfigured install over the network
+# could claim the admin account before the real operator does.
+ONBOARDING_INSTALL_TOKEN = config.get("ONBOARDING_INSTALL_TOKEN", "")
+ONBOARDING_INSTALL_TOKEN_FILE = os.path.join(BASE_DIR, "_storage", "install_token")
+
 LOGIN_REQUIRED_IGNORE_PATHS = [
     r'/login',
     r'/reset',


### PR DESCRIPTION
## Vulnerability

The onboarding wizard's account-creation step (`POST /onboarding/account`) created the first superuser with **no authentication or authorization check whatsoever**. Any unauthenticated attacker who reached a fresh (or reset) BackupSheep install before the owner completed setup could create their own admin account and take over the entire instance — including every stored backup credential.

This was exploited end-to-end against a live local instance: a single unauthenticated POST created an attacker-controlled superuser.

## Fix

The first-admin form now requires an **install token** that only someone with access to the server can read:

- On first boot the app generates a random token (`secrets.token_urlsafe(24)`) and writes it to `_storage/install_token` with mode `600`.
- An operator can alternatively set a fixed token via the new `ONBOARDING_INSTALL_TOKEN` env var (documented in `.env_sample`).
- The token is checked with `secrets.compare_digest` (constant-time) before the admin user is created; a missing/wrong token rejects the form with a clear error telling the operator where to read the token (`docker compose exec web cat /code/_storage/install_token`).
- The onboarding template renders the new required field with an explanatory info box.

Only the account-creation step is gated; the rest of the wizard already requires the logged-in admin.

## Files changed

- `backupsheep/settings.py` — `ONBOARDING_INSTALL_TOKEN` / `ONBOARDING_INSTALL_TOKEN_FILE` settings (note: this file was CRLF-only in the repo; it is normalized to LF here)
- `apps/console/onboarding/views.py` — token generation + constant-time check in `account()`
- `apps/console/onboarding/forms.py` — required `install_token` field on `AccountForm`
- `apps/console/_templates/console/onboarding/account.html` — field + help text
- `apps/console/onboarding/tests.py` — new test rejecting missing/wrong tokens; existing tests pass a valid token
- `.env_sample` — documents `ONBOARDING_INSTALL_TOKEN`

## Verification

- Exploit replay against the patched lab instance: unauthenticated POST without a token → form error, **no admin created**; with the correct token → works as before.
- Onboarding test suite: 9 tests, all passing.