### PR TITLE
fix: honor S3_DOWNLOAD_URL_EXPIRES in backup log URLs, drop dead vali…

### DIFF
--- a/apps/api/v1/backup/basecamp/views.py
+++ b/apps/api/v1/backup/basecamp/views.py
@@ -111,7 +111,7 @@ class CoreBasecampBackupView(viewsets.ModelViewSet):
                             "connection_name": backup.basecamp.node.connection.name,
                         },
                     )
-                    return Response({"url": download_url, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+                    return Response({"url": download_url, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
                 else:
                     raise DownloadStoragePointNotFound()
             except Exception as e:
@@ -144,9 +144,9 @@ class CoreBasecampBackupView(viewsets.ModelViewSet):
                 "Bucket": settings.AWS_S3_LOGS_BUCKET,
                 "Key": f"{backup.uuid_str}.log",
             },
-            ExpiresIn=24 * 3600,
+            ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
         )
-        return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+        return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
 
     @action(detail=True)
     def storage_points(self, request, pk=None):

--- a/apps/api/v1/backup/database/views.py
+++ b/apps/api/v1/backup/database/views.py
@@ -126,7 +126,7 @@ class CoreDatabaseBackupView(viewsets.ModelViewSet):
                             "connection_name": backup.database.node.connection.name,
                         },
                     )
-                    return Response({"url": download_url, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+                    return Response({"url": download_url, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
                 else:
                     raise DownloadStoragePointNotFound()
             except Exception as e:
@@ -224,7 +224,7 @@ class CoreDatabaseBackupView(viewsets.ModelViewSet):
                 expiration=timedelta(hours=24),
                 method="GET",
             )
-            return Response({"url": url, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": url, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         elif backup.created > date_aws_s3:
             s3_endpoint = f"https://{settings.AWS_S3_LOGS_ENDPOINT}"
 
@@ -248,9 +248,9 @@ class CoreDatabaseBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.AWS_S3_LOGS_BUCKET,
                     "Key": f"{backup.uuid_str}.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         elif date < backup.created < date_aws_s3:
             s3_client = boto3.client(
                 "s3",
@@ -265,10 +265,10 @@ class CoreDatabaseBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.LOGS_S3_BUCKET,
                     "Key": f"{backup.uuid_str}.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
             response = response.replace(f"{settings.LOGS_S3_ENDPOINT}/logs", "https://logs.backupsheep.com")
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         else:
             s3_client = boto3.client(
                 "s3",
@@ -282,9 +282,9 @@ class CoreDatabaseBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.AWS_LOGS_BUCKET,
                     "Key": f"{backup.uuid_str}.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
 
     @action(detail=False)
     def highcharts(self, request):

--- a/apps/api/v1/backup/website/views.py
+++ b/apps/api/v1/backup/website/views.py
@@ -130,7 +130,7 @@ class CoreWebsiteBackupView(viewsets.ModelViewSet):
                             "connection_name": backup.website.node.connection.name,
                         },
                     )
-                    return Response({"url": download_url, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+                    return Response({"url": download_url, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
                 else:
                     raise DownloadStoragePointNotFound()
             except Exception as e:
@@ -168,7 +168,7 @@ class CoreWebsiteBackupView(viewsets.ModelViewSet):
                 expiration=timedelta(hours=24),
                 method="GET",
             )
-            return Response({"url": url, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": url, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         elif backup.created > date_aws_s3:
             s3_endpoint = f"https://{settings.AWS_S3_LOGS_ENDPOINT}"
 
@@ -192,9 +192,9 @@ class CoreWebsiteBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.AWS_S3_LOGS_BUCKET,
                     "Key": f"{backup.uuid_str}.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         elif date < backup.created < date_aws_s3:
             s3_client = boto3.client(
                 "s3",
@@ -209,10 +209,10 @@ class CoreWebsiteBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.LOGS_S3_BUCKET,
                     "Key": f"{backup.uuid_str}.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
             response = response.replace(f"{settings.LOGS_S3_ENDPOINT}/logs", "https://logs.backupsheep.com")
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         else:
             s3_client = boto3.client(
                 "s3",
@@ -226,9 +226,9 @@ class CoreWebsiteBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.AWS_LOGS_BUCKET,
                     "Key": f"{backup.uuid_str}.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
 
     @action(detail=True)
     def download_dir_tree(self, request, pk=None):
@@ -268,9 +268,9 @@ class CoreWebsiteBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.AWS_S3_LOGS_BUCKET,
                     "Key": f"{backup.uuid_str}-dir-tree.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         elif date < backup.created < date_aws_s3:
             s3_client = boto3.client(
                 "s3",
@@ -285,10 +285,10 @@ class CoreWebsiteBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.LOGS_S3_BUCKET,
                     "Key": f"{backup.uuid_str}-dir-tree.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
             response = response.replace(f"{settings.LOGS_S3_ENDPOINT}/logs", "https://logs.backupsheep.com")
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         else:
             s3_client = boto3.client(
                 "s3",
@@ -302,9 +302,9 @@ class CoreWebsiteBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.AWS_LOGS_BUCKET,
                     "Key": f"{backup.uuid_str}-dir-tree.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
 
     @action(detail=True)
     def storage_points(self, request, pk=None):

--- a/apps/api/v1/backup/wordpress/views.py
+++ b/apps/api/v1/backup/wordpress/views.py
@@ -114,7 +114,7 @@ class CoreWordPressBackupView(viewsets.ModelViewSet):
                             "connection_name": backup.wordpress.node.connection.name,
                         },
                     )
-                    return Response({"url": download_url, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+                    return Response({"url": download_url, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
                 else:
                     raise DownloadStoragePointNotFound()
             except Exception as e:
@@ -140,7 +140,7 @@ class CoreWordPressBackupView(viewsets.ModelViewSet):
                 expiration=timedelta(hours=24),
                 method="GET",
             )
-            return Response({"url": url, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": url, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
         else:
             s3_endpoint = f"https://{settings.AWS_S3_LOGS_ENDPOINT}"
 
@@ -164,9 +164,9 @@ class CoreWordPressBackupView(viewsets.ModelViewSet):
                     "Bucket": settings.AWS_S3_LOGS_BUCKET,
                     "Key": f"{backup.uuid_str}.log",
                 },
-                ExpiresIn=24 * 3600,
+                ExpiresIn=int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600)),
             )
-            return Response({"url": response, "expire_in": 24 * 3600}, status=status.HTTP_201_CREATED)
+            return Response({"url": response, "expire_in": int(getattr(settings, "S3_DOWNLOAD_URL_EXPIRES", 24 * 3600))}, status=status.HTTP_201_CREATED)
 
     @action(detail=True)
     def storage_points(self, request, pk=None):

--- a/apps/console/storage/models.py
+++ b/apps/console/storage/models.py
@@ -2550,9 +2550,6 @@ class CoreStorage(TimeStampedModel):
             elif hasattr(self, 'storage_onedrive'):
                 storage = getattr(self, 'storage_onedrive')
                 return storage.validate()
-            elif hasattr(self, 'storage_googlecloud'):
-                storage = getattr(self, 'storage_googlecloud')
-                return storage.validate()
             elif hasattr(self, 'storage_vultr'):
                 storage = getattr(self, 'storage_vultr')
                 return storage.validate()


### PR DESCRIPTION
…date branch

- apps/api/v1/backup/{basecamp,database,website,wordpress}/views.py: presigned log-download URLs and their expire_in responses now use the configurable S3_DOWNLOAD_URL_EXPIRES setting instead of a hardcoded 24h, matching the backup download URLs.
- apps/console/storage/models.py: remove unreachable hasattr(self, 'storage_googlecloud') branch in CoreStorage.validate() (the related_name is storage_google_cloud, checked later in the chain).